### PR TITLE
Static library build

### DIFF
--- a/Source/Makefile
+++ b/Source/Makefile
@@ -1,6 +1,8 @@
 SDK=$$(xcrun --show-sdk-path --sdk macosx)
-OBJS=Value.o Real.o ValueArray.o ValueArraySlice.o ContiguousMemory.o Matrix.o
-SRC=./Types/Value.swift ./Array/ValueArray.swift ./Array/ValueArraySlice.swift ./Types/ContiguousMemory.swift ./Matrix/Matrix.swift ./Types/Real.swift ./Tensor/Tensor.swift ./Tensor/TensorSlice.swift ./Tensor/Span.swift ./Types/Interval.swift
+SWIFT=/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc
+OBJS=ValueArray.o ValueArraySlice.o Matrix.o MatrixArithmetic.o Tensor.o TensorSlice.o Span.o Arithmetic.o Auxiliary.o Exponential.o ContiguousMemory.o Interval.o Real.o Value.o
+SRC=./Array/ValueArray.swift ./Array/ValueArraySlice.swift ./Matrix/Matrix.swift ./Matrix/MatrixArithmetic.swift ./Tensor/Tensor.swift ./Tensor/TensorSlice.swift ./Tensor/Span.swift ./Operations/Arithmetic.swift ./Operations/Auxiliary.swift ./Operations/Exponential.swift ./Types/ContiguousMemory.swift ./Types/Interval.swift ./Types/Real.swift ./Types/Value.swift 
+VPATH = Array
 
 .PHONY: all
 all: lib module
@@ -13,6 +15,9 @@ module:
 
 $(OBJS): $(SRC)
 	xcrun swiftc -emit-library -emit-object $(SRC) -sdk $(SDK) -module-name Upsurge
+
+#ValueArray.o: ValueArray.swift
+#	$(SWIFT) -c -primary-file $< $(SRC) -sdk $(SDK) -module-name Upsurge -o $@
 
 .PHONY: clean
 clean:

--- a/Source/Makefile
+++ b/Source/Makefile
@@ -1,0 +1,19 @@
+SDK=$$(xcrun --show-sdk-path --sdk macosx)
+OBJS=Value.o Real.o ValueArray.o ValueArraySlice.o ContiguousMemory.o Matrix.o
+SRC=./Types/Value.swift ./Array/ValueArray.swift ./Array/ValueArraySlice.swift ./Types/ContiguousMemory.swift ./Matrix/Matrix.swift ./Types/Real.swift ./Tensor/Tensor.swift ./Tensor/TensorSlice.swift ./Tensor/Span.swift ./Types/Interval.swift
+
+.PHONY: all
+all: lib module
+
+lib: $(OBJS)
+	libtool -static -s -o libUpsurge.a -no_warning_for_no_symbols $(OBJS)
+
+module:
+	xcrun swiftc -emit-module $(SRC) -sdk $(SDK) -module-name Upsurge
+
+$(OBJS): $(SRC)
+	xcrun swiftc -emit-library -emit-object $(SRC) -sdk $(SDK) -module-name Upsurge
+
+.PHONY: clean
+clean:
+	rm -f *.o *.a *.swiftdoc *.swiftmodule

--- a/Source/Makefile
+++ b/Source/Makefile
@@ -1,23 +1,19 @@
+VPATH = Array Complex DSP Matrix Operations Tensor Types
 SDK=$$(xcrun --show-sdk-path --sdk macosx)
-SWIFT=/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc
-OBJS=ValueArray.o ValueArraySlice.o Matrix.o MatrixArithmetic.o Tensor.o TensorSlice.o Span.o Arithmetic.o Auxiliary.o Exponential.o ContiguousMemory.o Interval.o Real.o Value.o
-SRC=./Array/ValueArray.swift ./Array/ValueArraySlice.swift ./Matrix/Matrix.swift ./Matrix/MatrixArithmetic.swift ./Tensor/Tensor.swift ./Tensor/TensorSlice.swift ./Tensor/Span.swift ./Operations/Arithmetic.swift ./Operations/Auxiliary.swift ./Operations/Exponential.swift ./Types/ContiguousMemory.swift ./Types/Interval.swift ./Types/Real.swift ./Types/Value.swift 
-VPATH = Array
+SRC=ValueArray.swift ValueArraySlice.swift DSP.swift Matrix.swift MatrixArithmetic.swift Tensor.swift TensorSlice.swift Span.swift Arithmetic.swift Auxiliary.swift Exponential.swift Hyperbolic.swift Trigonometric.swift ContiguousMemory.swift Interval.swift Real.swift Value.swift 
+OBJS:=$(subst .swift,.o,$(SRC))
 
 .PHONY: all
-all: lib module
+all: libUpsurge.a Upsurge.swiftmodule
 
-lib: $(OBJS)
-	libtool -static -s -o libUpsurge.a -no_warning_for_no_symbols $(OBJS)
+libUpsurge.a: $(OBJS)
+	libtool -static -s -o $@ -no_warning_for_no_symbols $^
 
-module:
-	xcrun swiftc -emit-module $(SRC) -sdk $(SDK) -module-name Upsurge
+Upsurge.swiftmodule: $(SRC)
+	xcrun swiftc -emit-module $^ -sdk $(SDK) -module-name Upsurge
 
 $(OBJS): $(SRC)
-	xcrun swiftc -emit-library -emit-object $(SRC) -sdk $(SDK) -module-name Upsurge
-
-#ValueArray.o: ValueArray.swift
-#	$(SWIFT) -c -primary-file $< $(SRC) -sdk $(SDK) -module-name Upsurge -o $@
+	xcrun swiftc -emit-library -emit-object $^ -sdk $(SDK) -module-name Upsurge
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
This Makefile builds <code>libUpsurge.a</code> and <code>Upsurge.swiftmodule</code>. These two files can be added to any Swift project that requires Upsurge. Once the two files are added to an Xcode project, <code>import Upsurge</code> will use the module map to access Upsurge objects in the static library.

This is a temporary workaround for the problem that Xcode 7.1 does not build static libraries or usable frameworks that include swift code. 

Note:
- To reference the module map and static lib, in the end project, <code>Build Settings ->  Swift Compiler - Search Paths -> Import Paths</code> needs to have <code>$(SOURCE_ROOT)/path/to/files</code> set. i.e. if added under a <code>Lib</code> group, then set <code>$(SOURCE_ROOT)/Lib</code>
- The Upsurge code in the static library references the Accelerate framework but does not include it. The end project will require <code>import Accelerate</code> to ensure object file references link correctly.
- The <code>Complex.swift</code> object is not included at present. swiftc has an odd problem where it fails to build code that uses <code>hypot</code> or <code>atan2</code>
