### PR TITLE
Static library now includes all code

### DIFF
--- a/Source/Complex/Complex.swift
+++ b/Source/Complex/Complex.swift
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import Darwin
+
 public struct Complex : Value {
     public var real: Real = 0.0
     public var imag: Real = 0.0

--- a/Source/Makefile
+++ b/Source/Makefile
@@ -1,6 +1,8 @@
 SDK=$$(xcrun --show-sdk-path --sdk macosx)
-OBJS=Value.o Real.o ValueArray.o ValueArraySlice.o ContiguousMemory.o Matrix.o
-SRC=./Types/Value.swift ./Array/ValueArray.swift ./Array/ValueArraySlice.swift ./Types/ContiguousMemory.swift ./Matrix/Matrix.swift ./Types/Real.swift ./Tensor/Tensor.swift ./Tensor/TensorSlice.swift ./Tensor/Span.swift ./Types/Interval.swift
+SWIFT=/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc
+OBJS=ValueArray.o ValueArraySlice.o Matrix.o MatrixArithmetic.o Tensor.o TensorSlice.o Span.o Arithmetic.o Auxiliary.o Exponential.o ContiguousMemory.o Interval.o Real.o Value.o
+SRC=./Array/ValueArray.swift ./Array/ValueArraySlice.swift ./Matrix/Matrix.swift ./Matrix/MatrixArithmetic.swift ./Tensor/Tensor.swift ./Tensor/TensorSlice.swift ./Tensor/Span.swift ./Operations/Arithmetic.swift ./Operations/Auxiliary.swift ./Operations/Exponential.swift ./Types/ContiguousMemory.swift ./Types/Interval.swift ./Types/Real.swift ./Types/Value.swift 
+VPATH = Array
 
 .PHONY: all
 all: lib module
@@ -13,6 +15,9 @@ module:
 
 $(OBJS): $(SRC)
 	xcrun swiftc -emit-library -emit-object $(SRC) -sdk $(SDK) -module-name Upsurge
+
+#ValueArray.o: ValueArray.swift
+#	$(SWIFT) -c -primary-file $< $(SRC) -sdk $(SDK) -module-name Upsurge -o $@
 
 .PHONY: clean
 clean:

--- a/Source/Makefile
+++ b/Source/Makefile
@@ -1,0 +1,19 @@
+SDK=$$(xcrun --show-sdk-path --sdk macosx)
+OBJS=Value.o Real.o ValueArray.o ValueArraySlice.o ContiguousMemory.o Matrix.o
+SRC=./Types/Value.swift ./Array/ValueArray.swift ./Array/ValueArraySlice.swift ./Types/ContiguousMemory.swift ./Matrix/Matrix.swift ./Types/Real.swift ./Tensor/Tensor.swift ./Tensor/TensorSlice.swift ./Tensor/Span.swift ./Types/Interval.swift
+
+.PHONY: all
+all: lib module
+
+lib: $(OBJS)
+	libtool -static -s -o libUpsurge.a -no_warning_for_no_symbols $(OBJS)
+
+module:
+	xcrun swiftc -emit-module $(SRC) -sdk $(SDK) -module-name Upsurge
+
+$(OBJS): $(SRC)
+	xcrun swiftc -emit-library -emit-object $(SRC) -sdk $(SDK) -module-name Upsurge
+
+.PHONY: clean
+clean:
+	rm -f *.o *.a *.swiftdoc *.swiftmodule

--- a/Source/Makefile
+++ b/Source/Makefile
@@ -1,6 +1,6 @@
 VPATH = Array Complex DSP Matrix Operations Tensor Types
 SDK=$$(xcrun --show-sdk-path --sdk macosx)
-SRC=ValueArray.swift ValueArraySlice.swift DSP.swift Matrix.swift MatrixArithmetic.swift Tensor.swift TensorSlice.swift Span.swift Arithmetic.swift Auxiliary.swift Exponential.swift Hyperbolic.swift Trigonometric.swift ContiguousMemory.swift Interval.swift Real.swift Value.swift 
+SRC=ValueArray.swift ValueArraySlice.swift Matrix.swift MatrixArithmetic.swift Tensor.swift TensorSlice.swift Span.swift Arithmetic.swift Auxiliary.swift Exponential.swift Hyperbolic.swift Trigonometric.swift ContiguousMemory.swift Interval.swift Real.swift Value.swift Complex.swift ComplexArithmetic.swift ComplexArray.swift ComplexArrayRealSlice.swift DSP.swift FFT.swift
 OBJS:=$(subst .swift,.o,$(SRC))
 
 .PHONY: all

--- a/Source/Makefile
+++ b/Source/Makefile
@@ -1,23 +1,19 @@
+VPATH = Array Complex DSP Matrix Operations Tensor Types
 SDK=$$(xcrun --show-sdk-path --sdk macosx)
-SWIFT=/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc
-OBJS=ValueArray.o ValueArraySlice.o Matrix.o MatrixArithmetic.o Tensor.o TensorSlice.o Span.o Arithmetic.o Auxiliary.o Exponential.o ContiguousMemory.o Interval.o Real.o Value.o
-SRC=./Array/ValueArray.swift ./Array/ValueArraySlice.swift ./Matrix/Matrix.swift ./Matrix/MatrixArithmetic.swift ./Tensor/Tensor.swift ./Tensor/TensorSlice.swift ./Tensor/Span.swift ./Operations/Arithmetic.swift ./Operations/Auxiliary.swift ./Operations/Exponential.swift ./Types/ContiguousMemory.swift ./Types/Interval.swift ./Types/Real.swift ./Types/Value.swift 
-VPATH = Array
+SRC=ValueArray.swift ValueArraySlice.swift DSP.swift Matrix.swift MatrixArithmetic.swift Tensor.swift TensorSlice.swift Span.swift Arithmetic.swift Auxiliary.swift Exponential.swift Hyperbolic.swift Trigonometric.swift ContiguousMemory.swift Interval.swift Real.swift Value.swift 
+OBJS:=$(subst .swift,.o,$(SRC))
 
 .PHONY: all
-all: lib module
+all: libUpsurge.a Upsurge.swiftmodule
 
-lib: $(OBJS)
-	libtool -static -s -o libUpsurge.a -no_warning_for_no_symbols $(OBJS)
+libUpsurge.a: $(OBJS)
+	libtool -static -s -o $@ -no_warning_for_no_symbols $^
 
-module:
-	xcrun swiftc -emit-module $(SRC) -sdk $(SDK) -module-name Upsurge
+Upsurge.swiftmodule: $(SRC)
+	xcrun swiftc -emit-module $^ -sdk $(SDK) -module-name Upsurge
 
 $(OBJS): $(SRC)
-	xcrun swiftc -emit-library -emit-object $(SRC) -sdk $(SDK) -module-name Upsurge
-
-#ValueArray.o: ValueArray.swift
-#	$(SWIFT) -c -primary-file $< $(SRC) -sdk $(SDK) -module-name Upsurge -o $@
+	xcrun swiftc -emit-library -emit-object $^ -sdk $(SDK) -module-name Upsurge
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
For the Complex objects to build, I needed to <code>import Darwin</code> to get access to the math functions. The new library works for me in my end project but I am not using Complex objects. It may be necessary to <code>import Darwin</code> in the end project if link errors occur for <code>hypot</code>, <code>atan2</code> or the like. 
