### PR TITLE
Make slice base public

### DIFF
--- a/Source/Array/ValueArraySlice.swift
+++ b/Source/Array/ValueArraySlice.swift
@@ -22,7 +22,7 @@
 public struct ValueArraySlice<Element: Value> : ContiguousMutableMemory, MutableIndexable, CustomStringConvertible, Equatable {
     public typealias Index = Int
 
-    var base: ValueArray<Element>
+    public var base: ValueArray<Element>
     public var startIndex: Int
     public var endIndex: Int
     public var step: Int


### PR DESCRIPTION
Making this public allows you to extract a range from a ValueArray as a ValueArray using:

`let foo = myValueArray[0..<n].base`
