### PR TITLE
Remove build warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: objective-c
 xcode_workspace: Upsurge.xcworkspace
 xcode_scheme: Upsurge OSX
-osx_image: xcode7
+osx_image: xcode7.3

--- a/Source/1D/LinearOperators.swift
+++ b/Source/1D/LinearOperators.swift
@@ -46,7 +46,8 @@ public func +=<ML: MutableLinearType where ML.Element == Double>(inout lhs: ML, 
     }
 }
 
-public func +<ML: LinearType where ML.Element == Double>(lhs: ML, var rhs: Double) -> ValueArray<Double> {
+public func +<ML: LinearType where ML.Element == Double>(lhs: ML, rhs: Double) -> ValueArray<Double> {
+    var rhs = rhs
     let results = ValueArray<Double>(count: lhs.count)
     withPointer(lhs) { lhsp in
         vDSP_vsaddD(lhsp + lhs.startIndex, lhs.step, &rhs, results.mutablePointer + results.startIndex, results.step, vDSP_Length(lhs.count))
@@ -132,7 +133,8 @@ public func /<ML: LinearType where ML.Element == Double>(lhs: ML, rhs: Double) -
     return results
 }
 
-public func /<ML: LinearType where ML.Element == Double>(var lhs: Double, rhs: ML) -> ValueArray<Double> {
+public func /<ML: LinearType where ML.Element == Double>(lhs: Double, rhs: ML) -> ValueArray<Double> {
+    var lhs = lhs
     let results = ValueArray<Double>(count: rhs.count)
     withPointer(rhs) { rhsp in
         vDSP_svdivD(&lhs, rhsp + rhs.startIndex, rhs.step, results.mutablePointer + results.startIndex, results.step, vDSP_Length(rhs.count))
@@ -154,13 +156,15 @@ public func *<ML: LinearType, MR: LinearType where ML.Element == Double, MR.Elem
     return results
 }
 
-public func *=<ML: MutableLinearType where ML.Element == Double>(inout lhs: ML, var rhs: Double) {
+public func *=<ML: MutableLinearType where ML.Element == Double>(inout lhs: ML, rhs: Double) {
+    var rhs = rhs
     withPointer(&lhs) { lhsp in
         vDSP_vsmulD(lhsp + lhs.startIndex, lhs.step, &rhs, lhsp + lhs.startIndex, lhs.step, vDSP_Length(lhs.count))
     }
 }
 
-public func *<ML: LinearType where ML.Element == Double>(lhs: ML, var rhs: Double) -> ValueArray<Double> {
+public func *<ML: LinearType where ML.Element == Double>(lhs: ML, rhs: Double) -> ValueArray<Double> {
+    var rhs = rhs
     let results = ValueArray<Double>(count: lhs.count)
     withPointer(lhs) { lhsp in
         vDSP_vsmulD(lhsp + lhs.startIndex, lhs.step, &rhs, results.mutablePointer + results.startIndex, results.step, vDSP_Length(lhs.count))

--- a/Source/1D/LinearType.swift
+++ b/Source/1D/LinearType.swift
@@ -20,7 +20,7 @@
 
 /// The `LinearType` protocol should be implemented by any collection that stores its values in a contiguous memory block. This is the building block for one-dimensional operations that are single-instruction, multiple-data (SIMD).
 public protocol LinearType: CollectionType, TensorType {
-    typealias Element
+    associatedtype Element
 
     /// The index of the first valid element
     var startIndex: Int { get }

--- a/Source/2D/QuadraticType.swift
+++ b/Source/2D/QuadraticType.swift
@@ -27,7 +27,7 @@ public enum QuadraticArrangement {
 }
 
 public protocol QuadraticType: TensorType {
-    typealias Element
+    associatedtype Element
 
     /// The arrangement of rows and columns
     var arrangement: QuadraticArrangement { get }

--- a/Source/ND/TensorType.swift
+++ b/Source/ND/TensorType.swift
@@ -19,8 +19,8 @@
 // THE SOFTWARE.
 
 public protocol TensorType {
-    typealias Element
-    typealias Slice
+    associatedtype Element
+    associatedtype Slice
     
     /// A description of the dimensions over which the TensorType spans
     var span: Span { get }


### PR DESCRIPTION
Remove warnings when building with XCode by:
- change `typealias` declared in protocols to `associatedtype`
- fix var parameter. var parameter is deprecated.
