### PR TITLE
Fix bug in subtraction operator for scalar - VectorArray

### DIFF
--- a/Source/1D/LinearOperators.swift
+++ b/Source/1D/LinearOperators.swift
@@ -95,7 +95,7 @@ public func -<ML: LinearType>(lhs: Double, rhs: ML) -> ValueArray<Double> where 
     let results = ValueArray<Double>(count: rhs.count)
     withPointer(rhs) { rhsp in
         var scalarm: Double = -1
-        var scalara: Double = 0
+        var scalara: Double = lhs
         vDSP_vsmsaD(rhsp + rhs.startIndex, rhs.step, &scalarm, &scalara, results.mutablePointer + results.startIndex, results.step, vDSP_Length(rhs.count))
     }
     return results
@@ -264,7 +264,7 @@ public func -<ML: LinearType>(lhs: Float, rhs: ML) -> ValueArray<Float> where ML
     let results = ValueArray<Float>(count: rhs.count)
     withPointer(rhs) { rhsp in
         var scalarm: Float = -1
-        var scalara: Float = 0
+        var scalara: Float = lhs
         vDSP_vsmsa(rhsp + rhs.startIndex, rhs.step, &scalarm, &scalara, results.mutablePointer + results.startIndex, results.step, vDSP_Length(rhs.count))
     }
     return results

--- a/Tests/ArithmeticTests.swift
+++ b/Tests/ArithmeticTests.swift
@@ -128,16 +128,30 @@ class ArithmeticTests: XCTestCase {
         }
     }
 
-  func testStd() {
+    func testStd() {
         let a1: ValueArray<Double> = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]
         let r = std(a1)
         XCTAssertEqual(r, 2.0)
-  }
+    }
 
-  func testLinregress() {
+    func testLinregress() {
         let a1: ValueArray<Double> = [1.0, 2.0, 3.0, 4.0, 5.0]
         let (slope, intercept) = linregress(a1, a1)
         XCTAssertEqual(slope, 1.0)
         XCTAssertEqual(intercept, 0.0)
+    }
+    
+    func testScalarVectorSubtraction() {
+        let a1: ValueArray<Double> = [1.0, 2.0, 3.0]
+        let r1 = 1 - a1
+        XCTAssertEqual(r1[0], 0.0)
+        XCTAssertEqual(r1[1], -1.0)
+        XCTAssertEqual(r1[2], -2.0)
+        
+        let a2: ValueArray<Float> = [1.0, 2.0, 3.0]
+        let r2 = 1 - a2
+        XCTAssertEqual(r2[0], 0.0)
+        XCTAssertEqual(r2[1], -1.0)
+        XCTAssertEqual(r2[2], -2.0)
     }
 }


### PR DESCRIPTION
While debugging some machine learning code, I discovered that the subtraction operator for scalar - VectorArray was returning incorrect results. The first argument to the operator was being ignored and treated as 0.

My changes include both a fix and a new unit test.
