### PR TITLE
Fix warnings for Xcode 10.2.1 and Swift 5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.3
+osx_image: xcode10.2
 
 script:
   - set -o pipefail

--- a/Sources/Upsurge/2DTensorSlice.swift
+++ b/Sources/Upsurge/2DTensorSlice.swift
@@ -62,7 +62,7 @@ open class TwoDimensionalTensorSlice<Element: Value>: MutableQuadraticType, Equa
         assert(span.dimensions.reduce(0) { $1 > 1 ? $0 + 1 : $0 } <= 2)
         assert(span.dimensions.last! >= 1)
 
-        let rowIndex: Int = span.dimensions.index { $0 > 1 } ??
+        let rowIndex: Int = span.dimensions.firstIndex { $0 > 1 } ??
                            (span.dimensions.count - 2)
 
         rows = span.dimensions[rowIndex]
@@ -133,11 +133,11 @@ open class TwoDimensionalTensorSlice<Element: Value>: MutableQuadraticType, Equa
     }
 
     open var isContiguous: Bool {
-        let onesCount: Int = (dimensions.index { $0 != 1 }) ?? rank
+        let onesCount: Int = (dimensions.firstIndex { $0 != 1 }) ?? rank
 
         let diff = (0..<rank).map({ dimensions[$0] - base.dimensions[$0] }).reversed()
         let fullCount: Int
-        if let index = (diff.index { $0 != 0 }), index.base < count {
+        if let index = (diff.firstIndex { $0 != 0 }), index.base < count {
             fullCount = rank - index.base
         } else {
             fullCount = rank

--- a/Sources/Upsurge/2DTensorSlice.swift
+++ b/Sources/Upsurge/2DTensorSlice.swift
@@ -62,9 +62,11 @@ open class TwoDimensionalTensorSlice<Element: Value>: MutableQuadraticType, Equa
         assert(span.dimensions.reduce(0) { $1 > 1 ? $0 + 1 : $0 } <= 2)
         assert(span.dimensions.last! >= 1)
 
-        let rowIndex: Int = span.dimensions.firstIndex { $0 > 1 } ??
-                           (span.dimensions.count - 2)
-
+        #if swift(>=5.0)
+        let rowIndex: Int = span.dimensions.firstIndex { $0 > 1 } ?? (span.dimensions.count - 2)
+        #else
+        let rowIndex: Int = span.dimensions.index { $0 > 1 } ?? (span.dimensions.count - 2)
+        #endif
         rows = span.dimensions[rowIndex]
         columns = span.dimensions.last!
 
@@ -133,15 +135,27 @@ open class TwoDimensionalTensorSlice<Element: Value>: MutableQuadraticType, Equa
     }
 
     open var isContiguous: Bool {
+        #if swift(>=5.0)
         let onesCount: Int = (dimensions.firstIndex { $0 != 1 }) ?? rank
+        #else
+        let onesCount: Int = (dimensions.index { $0 != 1 }) ?? rank
+        #endif
 
         let diff = (0..<rank).map({ dimensions[$0] - base.dimensions[$0] }).reversed()
         let fullCount: Int
+        #if swift(>=5.0)
         if let index = (diff.firstIndex { $0 != 0 }), index.base < count {
             fullCount = rank - index.base
         } else {
             fullCount = rank
         }
+        #else
+        if let index = (diff.index { $0 != 0 }), index.base < count {
+            fullCount = rank - index.base
+        } else {
+            fullCount = rank
+        }
+        #endif
 
         return rank - fullCount - onesCount <= 1
     }

--- a/Sources/Upsurge/Complex.swift
+++ b/Sources/Upsurge/Complex.swift
@@ -59,8 +59,9 @@ public struct Complex<Element: Real>: Value {
         return Complex(real: x.magnitude, imag: 0.0)
     }
 
-    public var hashValue: Int {
-        return real.hashValue ^ imag.hashValue
+    public func hash(into: inout Hasher) {
+        into.combine(real)
+        into.combine(imag)
     }
 
     public var description: String {

--- a/Sources/Upsurge/LinearType.swift
+++ b/Sources/Upsurge/LinearType.swift
@@ -34,27 +34,27 @@ public protocol LinearType: TensorType, CustomStringConvertible, CustomDebugStri
 }
 
 public extension LinearType {
-    public var dimensions: [Int] {
+    var dimensions: [Int] {
         return [count]
     }
 
-    public func index(after i: Int) -> Int {
+    func index(after i: Int) -> Int {
         return i + 1
     }
 
-    public func index(before i: Int) -> Int {
+    func index(before i: Int) -> Int {
         return i - 1
     }
 
-    public func formIndex(after i: inout Int) {
+    func formIndex(after i: inout Int) {
         i += 1
     }
 
-    public var description: String {
+    var description: String {
         return "[\(map { "\($0)" }.joined(separator: ", "))]"
     }
 
-    public var debugDescription: String {
+    var debugDescription: String {
         return description
     }
 }

--- a/Sources/Upsurge/QuadraticType.swift
+++ b/Sources/Upsurge/QuadraticType.swift
@@ -46,11 +46,11 @@ public protocol QuadraticType: TensorType {
 
 public extension QuadraticType {
     /// The number of valid element in the memory block, taking into account the step size.
-    public var count: Int {
+    var count: Int {
         return rows * columns
     }
 
-    public var dimensions: [Int] {
+    var dimensions: [Int] {
         if arrangement == .rowMajor {
             return [rows, columns]
         } else {

--- a/Sources/Upsurge/TensorSlice.swift
+++ b/Sources/Upsurge/TensorSlice.swift
@@ -116,10 +116,10 @@ open class TensorSlice<Element: Value>: MutableTensorType, Equatable {
     }
 
     open var isContiguous: Bool {
-        let onesCount: Int = (dimensions.index { $0 != 1 }) ?? rank
+        let onesCount: Int = (dimensions.firstIndex { $0 != 1 }) ?? rank
         let diff = (0..<rank).map { dimensions[$0] - base.dimensions[$0] }.reversed()
         let fullCount: Int
-        if let index = (diff.index { $0 != 0 }), index.base < count {
+        if let index = (diff.firstIndex { $0 != 0 }), index.base < count {
             fullCount = rank - index.base
         } else {
             fullCount = rank

--- a/Sources/Upsurge/TensorType.swift
+++ b/Sources/Upsurge/TensorType.swift
@@ -38,17 +38,17 @@ public protocol TensorType {
 
 public extension TensorType {
     /// The size of each dimension
-    public var dimensions: [Int] {
+    var dimensions: [Int] {
         return span.dimensions
     }
 
     /// The number of dimensions
-    public var rank: Int {
+    var rank: Int {
         return span.rank
     }
 
     /// Convert a high-dimensional index into an integer index for a LinearType
-    public func linearIndex(_ indices: [Int]) -> Int {
+    func linearIndex(_ indices: [Int]) -> Int {
         precondition(indexIsValid(indices))
         var index = indices[0]
         for (i, dim) in span.dimensions[1..<rank].enumerated() {
@@ -58,7 +58,7 @@ public extension TensorType {
     }
 
     /// Check that an index falls within the span
-    public func indexIsValid(_ indices: [Int]) -> Bool {
+    func indexIsValid(_ indices: [Int]) -> Bool {
         return indices.count == rank && indices.enumerated().all { (i, index) in
             self.span[i].contains(index)
         }

--- a/Upsurge.xcodeproj/project.pbxproj
+++ b/Upsurge.xcodeproj/project.pbxproj
@@ -497,29 +497,33 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Venture Media Labs";
 				TargetAttributes = {
 					614ACA6F1BD1CB7B00A1C13E = {
 						CreatedOnToolsVersion = 7.0.1;
 						LastSwiftMigration = 0900;
+						ProvisioningStyle = Automatic;
 					};
 					614ACA791BD1CB7B00A1C13E = {
 						CreatedOnToolsVersion = 7.0.1;
 						LastSwiftMigration = 0900;
+						ProvisioningStyle = Automatic;
 					};
 					614ACAC91BD1CBF300A1C13E = {
 						CreatedOnToolsVersion = 7.0.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1020;
+						ProvisioningStyle = Automatic;
 					};
 					614ACAD21BD1CBF300A1C13E = {
 						CreatedOnToolsVersion = 7.0.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					61D0466C1C48BA5B00DB7279 = {
 						CreatedOnToolsVersion = 7.2;
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
 					};
 					61D046751C48BA5B00DB7279 = {
 						CreatedOnToolsVersion = 7.2;
@@ -529,10 +533,11 @@
 			};
 			buildConfigurationList = 614ACA6A1BD1CB7B00A1C13E /* Build configuration list for PBXProject "Upsurge" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 614ACA661BD1CB7B00A1C13E;
 			productRefGroup = 614ACA711BD1CB7B00A1C13E /* Products */;
@@ -817,6 +822,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -876,6 +882,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -926,6 +933,8 @@
 		614ACA851BD1CB7B00A1C13E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -938,6 +947,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.venturemedia.Upsurge-OSX";
 				PRODUCT_NAME = Upsurge;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -945,6 +955,8 @@
 		614ACA861BD1CB7B00A1C13E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -957,6 +969,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.venturemedia.Upsurge-OSX";
 				PRODUCT_NAME = Upsurge;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
@@ -966,11 +979,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = Tests/UpsurgeTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.venturemedia.UpsurgeTests-OSX";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
 		};
@@ -978,11 +994,14 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = Tests/UpsurgeTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.venturemedia.UpsurgeTests-OSX";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 			};
 			name = Release;
@@ -990,7 +1009,9 @@
 		614ACADC1BD1CBF300A1C13E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1000,8 +1021,10 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.venturemedia.Upsurge-iOS";
 				PRODUCT_NAME = Upsurge;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -1009,7 +1032,9 @@
 		614ACADD1BD1CBF300A1C13E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1019,9 +1044,11 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.venturemedia.Upsurge-iOS";
 				PRODUCT_NAME = Upsurge;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -1039,6 +1066,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.venturemedia.UpsurgeTests-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1055,6 +1083,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -1062,7 +1091,9 @@
 		61D0467E1C48BA5B00DB7279 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1072,6 +1103,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.venturemedia.Upsurge-tvOS";
 				PRODUCT_NAME = Upsurge;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
@@ -1082,7 +1114,9 @@
 		61D0467F1C48BA5B00DB7279 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1092,6 +1126,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.venturemedia.Upsurge-tvOS";
 				PRODUCT_NAME = Upsurge;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";

--- a/Upsurge.xcodeproj/project.pbxproj
+++ b/Upsurge.xcodeproj/project.pbxproj
@@ -872,7 +872,7 @@
 				SDKROOT = macosx;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -924,7 +924,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -933,7 +933,7 @@
 		614ACA851BD1CB7B00A1C13E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
@@ -949,6 +949,7 @@
 				PRODUCT_NAME = Upsurge;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -972,6 +973,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -979,9 +981,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/UpsurgeTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.venturemedia.UpsurgeTests-OSX";
@@ -994,9 +997,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/UpsurgeTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.venturemedia.UpsurgeTests-OSX";
@@ -1009,8 +1013,6 @@
 		614ACADC1BD1CBF300A1C13E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1032,8 +1034,6 @@
 		614ACADD1BD1CBF300A1C13E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1058,8 +1058,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/UpsurgeTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1074,8 +1072,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/UpsurgeTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -1091,8 +1087,6 @@
 		61D0467E1C48BA5B00DB7279 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1114,8 +1108,6 @@
 		61D0467F1C48BA5B00DB7279 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/Upsurge.xcodeproj/xcshareddata/xcschemes/Upsurge OSX.xcscheme
+++ b/Upsurge.xcodeproj/xcshareddata/xcschemes/Upsurge OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Upsurge.xcodeproj/xcshareddata/xcschemes/Upsurge iOS.xcscheme
+++ b/Upsurge.xcodeproj/xcshareddata/xcschemes/Upsurge iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Upsurge.xcodeproj/xcshareddata/xcschemes/Upsurge tvOS.xcscheme
+++ b/Upsurge.xcodeproj/xcshareddata/xcschemes/Upsurge tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Small edits to silence warnings. However, two edits `iIndex` -> `firstIndex` to remove deprecated APII might be a tad too much to remain backwards compatible.
